### PR TITLE
Fixed Some Wording Things

### DIFF
--- a/docs/bugs/bug-hunter/approve-deny.md
+++ b/docs/bugs/bug-hunter/approve-deny.md
@@ -5,7 +5,7 @@ As a Bug Hunter:tm: you have the ~~holy~~ respectful ability to approve and deny
 When approving or denying a bug, it's good etiquette to:
 - Avoid using shorthands if possible
 - Include all relevant system and client information
-- Don't use dynamic terms, like "latest build" or "newest mac". Be as **specific** as you can be!
+- Don't use dynamic terms, like "latest build" or "newest mac". Be as **specific** as can be!
 - Be respectful
 - With duplicate reports, include links to the Trello ticket
 
@@ -26,8 +26,10 @@ If a report has already been *approved* and a report highlighting the same issue
 `!deny 0001 | Duplicate Ticket of https://trello.com/abcd1234. Please check the Trello boards before reporting.`
 
 ### Cannot Reproduce
-If you cannot reproduce the bug, and you're on the same platform (ignore device and operating system unless marked as specific or in a specific operating system flow. And take note of the build number as it may be outdated, just be safe and check it on the latest build as the developers might've already fixed it, if the user isn't on the latest build, make sure to let them know that they should update), you can deny the report.  
-`!deny 0001 | Cannot Reproduce - MacBook Air 2013 13" [10.12.6 Sierra], Discord Canary [0.0.154]`
+If you cannot reproduce the bug, and you're on the same platform (ignore device and operating system unless marked as specific or in a specific operating system flow), you can deny the report.  
+`!deny 0001 | Cannot Reproduce - MacBook Air 2013 13" [10.12.6 Sierra], Discord Canary [0.0.154]`  
+
+If they are more then two builds out from the current build, or one major build away, make sure to get them to update their client and see if they can still reproduce the bug. It may have been patched in a recent update.
 
 ### Not a Bug
 Not to be confused with intended behaviour, not a bug means that the report... well.. isn't a bug... At least one of the three deny messages should contain a short explanation as to why it's not a bug.  

--- a/docs/bugs/bug-hunter/approve-deny.md
+++ b/docs/bugs/bug-hunter/approve-deny.md
@@ -5,7 +5,7 @@ As a Bug Hunter:tm: you have the ~~holy~~ respectful ability to approve and deny
 When approving or denying a bug, it's good etiquette to:
 - Avoid using shorthands if possible
 - Include all relevant system and client information
-- Use dynamic terms, like "latest build" or "newest mac"
+- Don't use dynamic terms, like "latest build" or "newest mac". Be as **specific** as you can be!
 - Be respectful
 - With duplicate reports, include links to the Trello ticket
 
@@ -26,7 +26,7 @@ If a report has already been *approved* and a report highlighting the same issue
 `!deny 0001 | Duplicate Ticket of https://trello.com/abcd1234. Please check the Trello boards before reporting.`
 
 ### Cannot Reproduce
-If you cannot reproduce the bug, and you're on the same platform (ignore device and build unless marked as specific), you can deny the report.  
+If you cannot reproduce the bug, and you're on the same platform (ignore device and operating system unless marked as specific or in a specific operating system flow. And take note of the build number as it may be outdated, just be safe and check it on the latest build as the developers might've already fixed it, if the user isn't on the latest build, make sure to let them know that they should update), you can deny the report.  
 `!deny 0001 | Cannot Reproduce - MacBook Air 2013 13" [10.12.6 Sierra], Discord Canary [0.0.154]`
 
 ### Not a Bug

--- a/docs/bugs/bugbot.md
+++ b/docs/bugs/bugbot.md
@@ -1,6 +1,6 @@
 # Bug Bot
 Bug Bot (Bug-Bot#1660) is the Official bot that powers the Discord Testers program. It links between the Guild/Server and Trello, powers reporting, approving and denying as well as attachments. Honestly, without Bug Bot, Discord wouldn't be half as good as it is now.  Not all commands are included here, as some are Administrator only commands.
-P.S. Bug Bot's open-source! Check him out @ [SamEm/Bug-Bot](https://github.com/SamEm/Bug-Bot)!
+P.S. Bug Bot's open-source! Check her out @ [SamEm/Bug-Bot](https://github.com/SamEm/Bug-Bot)!
 
 ## Using her - Users
 Command | Description

--- a/docs/bugs/reporting.md
+++ b/docs/bugs/reporting.md
@@ -40,5 +40,5 @@ Just generally, don't be a dick and you'll be golden.
 
 - [Windows Canary Download](https://discordapp.com/api/download/canary?platform=win)
 - [macOS Canary Download](https://discordapp.com/api/download/canary?platform=osx)
-- [Linus Canary Download](https://discordapp.com/api/download/canary?platform=linux)
+- [Linux Canary Download](https://discordapp.com/api/download/canary?platform=linux)
 - [Testflight and Android Alpha Registration](https://dabbit.typeform.com/to/ycZl9m) - Android Alpha must register with Google Play email.


### PR DESCRIPTION
Line 8: The line should say "Don't use dynamic terms", the dynamic terms do not help the devs in the slightest, because if the user is on an outdated "latest" version, the devs may waste valuable time trying to figure out why it is still "happening" when it isn't.

Line 29: The line shouldn't tell users to ignore the build number, only the device and operating system, because if a user is ignoring the build number, and the user who reported it is not on the latest build, then the devs might have fixed it already but the user hasn't updated yet. It got a bit longer, but we shouldn't be worrying about length over detail.